### PR TITLE
Create codespell_and_ruff.yml

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -1,0 +1,21 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://docs.astral.sh/ruff/
+name: codespell_and_ruff
+on:
+  push:
+    branches: [master, patches]
+  pull_request:
+    branches: [master, patches]
+jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell --ignore-words-list=mathes,millon,ned --skip="*.csv,*.rss"
+    - run: ruff --output-format=github --ignore=E401,E402,E701,E712,E713,E721,E722,E731,E741,F401,F403,F405,F811,F821,F841
+                --exclude=doc/docstring.py,doc/conf.py,scripts/mkrelease.py,scripts/mkwiki.py,scripts/mkindex.py,examples/attrib_plugin.py
+

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -170,7 +170,7 @@
 - Fixed an ugly traceback when a test class was imported from another module,
   but was missing a method. (#595)
   Patch by Michael Williamson.
-- Fix formatFailure expection if missing tb in exc_info. (#603)
+- Fix formatFailure exception if missing tb in exc_info. (#603)
   Patch by Sascha Peilicke.
 - Taught the test suite to skip coverage tests if the coverage module is not
   available. (#597)
@@ -238,7 +238,7 @@
   Andrey Golovizin.
 - Add --cover-min-percentage flag to force test runs without sufficient
   coverage to fail (#540). Patch by Domen Kožar.
-- Add travis-ci configuraion (#545). Patch by Domen Kožar.
+- Add travis-ci configuration (#545). Patch by Domen Kožar.
 - Call reactor.stop from twisted thread (#301). Patch by Adi Roiban.
 
 
@@ -455,7 +455,7 @@
 - Fixed bug in capture plugin that caused it to record captured output
   on the test in the wrong attribute (#113).
 - Fixed bug in result proxy that caused tests to fail if they accessed
-  certain result attibutes directly (#114). Thanks to Neilen Marais
+  certain result attributes directly (#114). Thanks to Neilen Marais
   for the bug report.
 - Fixed bug in capture plugin that caused other error formatters
   changes to be lost if no output was captured (#124). Thanks to
@@ -511,7 +511,7 @@
   Lee for many bug reports.
 - Fixed bugs in rpm generation (Issue #96). Thanks to Mike Verdone for
   the bug report and http://bugs.python.org/issue644744 for the fix.
-- Fixed inconsisent use of os.environ in plugin testing
+- Fixed inconsistent use of os.environ in plugin testing
   utilities. Thanks to John J Lee for the bug report and patch (Issue
   #97).
 - Fixed bug in test_address that prevented use of nose.case.Test in
@@ -575,7 +575,7 @@
   nose.plugins.0-10 and provides limited support for legacy plugins
   loaded under the entrypoint nose.plugins.
 - Added plugin hooks in all phases of discovery, running and description.
-- Converted several formely core features to plugins: output capture,
+- Converted several formerly core features to plugins: output capture,
   assert introspection, pdb, and skipped and deprecated test support.
 - Added id plugin that allows for easier specification of tests on the
   command line.
@@ -638,7 +638,7 @@
 - Fixed bug in handling of options from setup.cfg. Thanks to Kumar McMillan for
   the patch.
 - Fixed bug in generator methods, where a generator method using an inline
-  funciton would result in an AttributeError. Thanks to Antoine Pitrou for the
+  function would result in an AttributeError. Thanks to Antoine Pitrou for the
   bug report.
 - Updated coverage plugin to ignore lines tagged with #pragma: no cover,
   matching the behavior of coverage.py on the command line. Thanks to Bill
@@ -815,7 +815,7 @@
 - Fix bug where sys.path would not be set up correctly when running some
   tests, producing spurious import errors (Thanks to Titus Brown and Mike
   Thomson for the bug reports)
-- For test classses not derived from unittest.TestCase, output (module.Class)
+- For test classes not derived from unittest.TestCase, output (module.Class)
   "doc string" as test description, when method doc string is available
   (Thanks to David Keeney for the suggestion, even if this isn't quite what he
   meant)

--- a/NOTES
+++ b/NOTES
@@ -4,7 +4,7 @@ is the selector useful? can it die, if we assume a more directed loading
 approach?
 
 The loader is the heart of the discovery system. It should be simple, clear,
-and close to unittest's loader whereever possible. The complication comes from
+and close to unittest's loader wherever possible. The complication comes from
 supporting proper fixture setup and teardown when the test name requested is a
 or is inside of a dotted module. Say we run like this:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ nose3 is a drop-in fork of nose v1 that is compatible with Python 2.7
 and Python 3.3-3.10 without using lib2to3 or other compatibility layer.
 It does not yet support Python 3.11.
 
-It may support Python 2.6 and 3.2, or more dead snakes but that hasnt
+It may support Python 2.6 and 3.2, or more dead snakes but that hasn't
 been tested. Patches welcome.
 
 nose extends the test loading and running features of unittest, making

--- a/README.txt
+++ b/README.txt
@@ -16,8 +16,8 @@ removed:
    verbosity=3
    with-doctest=1
 
-There is also possiblity to disable configuration files loading (might
-be useful when runnig i.e. tox and you don't want your global nose
+There is also possibility to disable configuration files loading (might
+be useful when running i.e. tox and you don't want your global nose
 config file to be used by tox). In order to ignore those configuration
 files simply set an environment variable "NOSE_IGNORE_CONFIG_FILES".
 

--- a/functional_tests/doc_tests/test_doctest_fixtures/doctest_fixtures.rst
+++ b/functional_tests/doc_tests/test_doctest_fixtures/doctest_fixtures.rst
@@ -65,7 +65,7 @@ Example::
       test.globs['count'] = len(called)
   setup_test.__test__ = False
       
-**teardown_test(test)** is alled after the test, unless setup raised an
+**teardown_test(test)** is called after the test, unless setup raised an
 uncaught exception. The argument is the :class:`doctest.DocFileCase` object,
 *not* a unittest.TestCase.
 

--- a/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst
+++ b/functional_tests/doc_tests/test_selector_plugin/selector_plugin.rst
@@ -7,7 +7,7 @@ the most part, if an object's name matches the ``testMatch`` regular
 expression defined in the active `nose.config.Config` instance, the
 object is selected as a test. 
 
-This behavior is fine for new projects, but may be undesireable for
+This behavior is fine for new projects, but may be undesirable for
 older projects with a different test naming scheme. Fortunately, you
 can easily override this behavior by providing a custom selector using
 a plugin.

--- a/functional_tests/test_multiprocessing/test_keyboardinterrupt.py
+++ b/functional_tests/test_multiprocessing/test_keyboardinterrupt.py
@@ -36,7 +36,7 @@ def waitForKillFile(killfile):
 runner = os.path.join(support, 'fake_nosetest.py')
 def keyboardinterrupt(case):
     #os.setsid would create a process group so signals sent to the
-    #parent process will propogates to all children processes
+    #parent process will propagates to all children processes
     if not hasattr(os, 'setsid') or not hasattr(os, 'killpg'):
         raise SkipTest("OS does not support os.setsid or os.killpg")
 

--- a/nose/config.py
+++ b/nose/config.py
@@ -26,7 +26,7 @@ config_files = [
     "~/nose.cfg"
     ]
 
-# plaforms on which the exe check defaults to off
+# platforms on which the exe check defaults to off
 # Windows and IronPython
 exe_allowed_platforms = ('win32', 'cli')
 

--- a/nose/ext/dtcompat.py
+++ b/nose/ext/dtcompat.py
@@ -408,7 +408,7 @@ class Example:
         zero-based, with respect to the beginning of the DocTest.
 
       - indent: The example's indentation in the DocTest string.
-        I.e., the number of space characters that preceed the
+        I.e., the number of space characters that precede the
         example's first prompt.
 
       - options: A dictionary mapping from option flags to True or
@@ -1171,7 +1171,7 @@ class DocTestRunner:
         # Process each example.
         for examplenum, example in enumerate(test.examples):
 
-            # If REPORT_ONLY_FIRST_FAILURE is set, then supress
+            # If REPORT_ONLY_FIRST_FAILURE is set, then suppress
             # reporting after the first failure.
             quiet = (self.optionflags & REPORT_ONLY_FIRST_FAILURE and
                      failures > 0)

--- a/nose/plugins/base.py
+++ b/nose/plugins/base.py
@@ -110,7 +110,7 @@ class Plugin(object):
             return textwrap.dedent(self.__class__.__doc__)
         return "(no help available)"
 
-    # Compatiblity shim
+    # Compatibility shim
     def tolist(self, val):
         warn("Plugin.tolist is deprecated. Use nose.util.tolist instead",
              DeprecationWarning)

--- a/nose/plugins/doctests.py
+++ b/nose/plugins/doctests.py
@@ -145,7 +145,7 @@ class Doctest(Plugin):
     suiteClass = DoctestSuite
     
     def options(self, parser, env):
-        """Register commmandline options.
+        """Register commandline options.
         """
         Plugin.options(self, parser, env)
         parser.add_option('--doctest-tests', action='store_true',
@@ -384,7 +384,7 @@ class DocTestCase(doctest.DocTestCase):
     
     # doctests loaded via find(obj) omit the module name
     # so we need to override id, __repr__ and shortDescription
-    # bonus: this will squash a 2.3 vs 2.4 incompatiblity
+    # bonus: this will squash a 2.3 vs 2.4 incompatibility
     def id(self):
         name = self._dt_test.name
         filename = self._dt_test.filename

--- a/nose/plugins/failuredetail.py
+++ b/nose/plugins/failuredetail.py
@@ -17,7 +17,7 @@ class FailureDetail(Plugin):
     score = 1600 # before capture
     
     def options(self, parser, env):
-        """Register commmandline options.
+        """Register commandline options.
         """
         parser.add_option(
             "-d", "--detailed-errors", "--failure-detail",

--- a/nose/pyversion.py
+++ b/nose/pyversion.py
@@ -175,7 +175,7 @@ else:
     try:
         from compiler.consts import CO_GENERATOR
     except ImportError:
-        # IronPython doesn't have a complier module
+        # IronPython doesn't have a compiler module
         CO_GENERATOR=0x20
 
     def isgenerator(func):

--- a/nose/twistedtools.py
+++ b/nose/twistedtools.py
@@ -78,7 +78,7 @@ def stop_reactor():
     global _twisted_thread
 
     def stop_reactor():
-        '''Helper for calling stop from withing the thread.'''
+        '''Helper for calling stop from within the thread.'''
         reactor.stop()
 
     reactor.callFromThread(stop_reactor)
@@ -98,7 +98,7 @@ def deferred(timeout=None):
     The optional timeout parameter specifies the maximum duration of the test.
     The difference with timed() is that timed() will still wait for the test
     to end, while deferred() will stop the test when its timeout has expired.
-    The latter is more desireable when dealing with network tests, because
+    The latter is more desirable when dealing with network tests, because
     the result may actually never arrive.
 
     If the callback is triggered, the test has passed.

--- a/nose/util.py
+++ b/nose/util.py
@@ -116,7 +116,7 @@ def absfile(path, where=None):
     if path is None or not os.path.exists(path):
         return None
     if os.path.isdir(path):
-        # might want an __init__.py from pacakge
+        # might want an __init__.py from package
         init = os.path.join(path,'__init__.py')
         if os.path.isfile(init):
             return init

--- a/unit_tests/test_inspector.py
+++ b/unit_tests/test_inspector.py
@@ -30,14 +30,14 @@ class TestExpander(unittest.TestCase):
         out = ''
         try:
             assert a < 1, \
-                "This is a multline expression"
+                "This is a multiline expression"
         except AssertionError:
             et, ev, tb = sys.exc_info()
             out = inspect_traceback(tb)
             # print "'%s'" % out.strip()
             self.assertEqual(out.strip(),
                              '>>  assert 6 < 1, \\\n        '
-                             '"This is a multline expression"')
+                             '"This is a multiline expression"')
 
     def test_get_tb_source_simple(self):
         # no func frame

--- a/unit_tests/test_multiprocess.py
+++ b/unit_tests/test_multiprocess.py
@@ -46,7 +46,7 @@ class T(unittest.TestCase):
         pass
 
 def test_mp_process_args_pickleable():
-    # TODO(Kumar) this test needs to be more succint.
+    # TODO(Kumar) this test needs to be more succinct.
     # If you start seeing it timeout then perhaps we need to skip it again.
     # raise SkipTest('this currently gets stuck in poll() 90% of the time')
     test = case.Test(T('runTest'))


### PR DESCRIPTION
__codespell_and_ruff / codespell_and_ruff (pull_request) Successful in 5s__
* https://pypi.org/project/codespell
* https://pypi.org/project/ruff
```
codespell --ignore-words-list=mathes,millon,ned --skip="*.csv,*.rss"
ruff --output-format=github --ignore=E401,E402,E701,E712,E713,E721,E722,E731,E741,F401,F403,F405,F811,F821,F841
     --exclude=doc/docstring.py,doc/conf.py,scripts/mkrelease.py,scripts/mkwiki.py,scripts/mkindex.py,examples/attrib_plugin.py
```
Note: All `exclude` files have Python 3 Syntax Errors!!!